### PR TITLE
feat: Add placeholder to empty columns

### DIFF
--- a/main.js
+++ b/main.js
@@ -273,10 +273,26 @@ addColumnButton.addEventListener('click', async () => {
     column.appendChild(columnHeader);
     procedureGrid.appendChild(column);
 
+    const placeholder = document.createElement('div');
+    placeholder.className = 'column-placeholder';
+    placeholder.textContent = 'Drag cards here';
+    column.appendChild(placeholder);
+
     new Sortable(column, {
         group: 'procedures',
         animation: 150,
         ghostClass: 'sortable-ghost',
+        filter: '.column-placeholder',
+        onEnd: function (evt) {
+            // Check source column. If it's empty, show placeholder.
+            if (evt.from.querySelectorAll('.procedure-card').length === 0) {
+                const fromPlaceholder = evt.from.querySelector('.column-placeholder');
+                if (fromPlaceholder) fromPlaceholder.style.display = 'flex';
+            }
+            // Check destination column. If it has cards, hide placeholder.
+            const toPlaceholder = evt.to.querySelector('.column-placeholder');
+            if (toPlaceholder) toPlaceholder.style.display = 'none';
+        }
     });
 });
 
@@ -648,10 +664,30 @@ async function loadProcedures() {
 
     // Initialize SortableJS for each column
     document.querySelectorAll('.grid-column').forEach(column => {
+        const placeholder = document.createElement('div');
+        placeholder.className = 'column-placeholder';
+        placeholder.textContent = 'Drag cards here';
+        column.appendChild(placeholder);
+
+        if (column.querySelectorAll('.procedure-card').length > 0) {
+            placeholder.style.display = 'none';
+        }
+
         new Sortable(column, {
             group: 'procedures', // Allow dragging between columns
             animation: 150,
             ghostClass: 'sortable-ghost',
+            filter: '.column-placeholder',
+            onEnd: function (evt) {
+                // Check source column
+                if (evt.from.querySelectorAll('.procedure-card').length === 0) {
+                    const fromPlaceholder = evt.from.querySelector('.column-placeholder');
+                    if (fromPlaceholder) fromPlaceholder.style.display = 'flex';
+                }
+                // Check destination column
+                const toPlaceholder = evt.to.querySelector('.column-placeholder');
+                if (toPlaceholder) toPlaceholder.style.display = 'none';
+            }
         });
     });
 

--- a/style.css
+++ b/style.css
@@ -330,6 +330,19 @@ button:hover {
     box-shadow: 0 0 5px var(--accent-primary-shadow); /* Subtle glow effect */
 }
 
+.column-placeholder {
+    background-color: transparent;
+    border: 2px dashed var(--border-primary);
+    border-radius: 6px;
+    min-height: 38px; /* Matches the approximate height of a procedure card */
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary);
+    font-size: 0.9em;
+}
+
 .card-header {
     text-align: left;
     margin: 0;


### PR DESCRIPTION
Adds a visual placeholder to new and empty columns in the procedure grid.

The placeholder is a dashed box with the text "Drag cards here" to indicate that it is a drop target.

The visibility of the placeholder is handled dynamically:
- It is shown in columns that are empty on page load.
- It is shown in new columns when they are added.
- It is hidden when a card is dropped into a column.
- It is shown in a column if it becomes empty after a card is dragged out.