### PR TITLE
fix: Ensure empty columns have a minimum width

### DIFF
--- a/style.css
+++ b/style.css
@@ -309,6 +309,7 @@ button:hover {
     flex-direction: column;
     gap: 10px; /* Spacing between cards in a column */
     min-height: 50px; /* Ensure even empty columns are droppable */
+    min-width: 250px; /* Add this line */
 }
 
 /* Procedure Card */


### PR DESCRIPTION
The placeholder in empty columns was not fully visible because the column itself had no minimum width and would collapse.

This change adds a `min-width` of `250px` to the `.grid-column` class, ensuring that all columns, including empty ones, have a consistent minimum width. This makes the placeholder visible and improves the overall layout consistency.