### PR TITLE
feat: Add procedure selector page

### DIFF
--- a/selector.js
+++ b/selector.js
@@ -142,10 +142,19 @@ async function handleToggle(procedureId, isVisible) {
         }
     }
 
+    // Create a clean array for the upsert, sending only the required fields.
+    const preferencesToUpsert = currentPreferences.map(p => ({
+        user_id: p.user_id,
+        procedure_id: p.procedure_id,
+        is_visible: p.is_visible,
+        display_column: p.display_column,
+        display_row: p.display_row,
+    }));
+
     // Upsert the final, merged state, ensuring what the user sees is what gets saved.
     const { error: upsertError } = await supaClient
         .from('user_procedure_preferences')
-        .upsert(currentPreferences, { onConflict: 'user_id, procedure_id' });
+        .upsert(preferencesToUpsert, { onConflict: 'user_id, procedure_id' });
 
     if (upsertError) {
         console.error('Error upserting full preference set:', upsertError);


### PR DESCRIPTION
This commit introduces a new page that allows users to customize which procedures are displayed on the main grid.

Key changes:
- Creates a new `/selector.html` page with a corresponding `selector.js` file.
- The selector page displays all available procedures with toggle switches to control their visibility.
- User preferences are saved to the `user_procedure_preferences` table automatically. The save logic reads the state of all toggles on the page to ensure the saved state matches the UI, fixing a bug where toggling off was not saved.
- Implements a "snapshot" logic to preserve the default layout when a user makes their first customization, fixing a bug where the layout was being reset.
- When a new procedure is enabled, it is placed in a new column on the far right of the main grid. The logic correctly creates a new `user_columns` entry if needed.
- Adds a "Select procedures" link to the settings dropdown on the main page.
- Updates the `main.js` logic to correctly load the user's custom layout, respecting the `is_visible` flag.
- Adds CSS for the new page elements to ensure a consistent look and feel.