### PR TITLE
feat: Display procedures in a table view

### DIFF
--- a/selector.html
+++ b/selector.html
@@ -11,7 +11,23 @@
         <a href="main.html" style="text-decoration: none; color: var(--accent-primary); font-weight: bold;">Back to Main</a>
         <h1 style="color: white; margin: 0 auto;">Select Procedures</h1>
     </nav>
-    <main class="procedure-list-container"></main>
+    <main>
+        <table class="procedure-table">
+            <thead>
+                <tr>
+                    <th>cpt_code</th>
+                    <th>abbreviation</th>
+                    <th>description</th>
+                    <th>modality</th>
+                    <th>wrVU</th>
+                    <th>Visible</th>
+                </tr>
+            </thead>
+            <tbody class="procedure-list-container">
+                <!-- Procedure rows will be inserted here by JavaScript -->
+            </tbody>
+        </table>
+    </main>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="selector.js"></script>
 </body>

--- a/selector.js
+++ b/selector.js
@@ -44,18 +44,24 @@ async function loadProceduresAndPreferences() {
         const userPreference = preferencesMap.get(procedure.id);
         const isVisible = userPreference ? userPreference.is_visible : procedure.default_display;
 
-        const procedureItem = document.createElement('div');
-        procedureItem.classList.add('procedure-item');
+        const procedureRow = document.createElement('tr');
+        procedureRow.classList.add('procedure-item');
 
-        procedureItem.innerHTML = `
-            <span class="procedure-name">${procedure.description}</span>
-            <label class="switch">
-                <input type="checkbox" ${isVisible ? 'checked' : ''} data-procedure-id="${procedure.id}">
-                <span class="slider round"></span>
-            </label>
+        procedureRow.innerHTML = `
+            <td>${procedure.cpt_code}</td>
+            <td>${procedure.abbreviation}</td>
+            <td>${procedure.description}</td>
+            <td>${procedure.modality}</td>
+            <td>${procedure.wrVU}</td>
+            <td>
+                <label class="switch">
+                    <input type="checkbox" ${isVisible ? 'checked' : ''} data-procedure-id="${procedure.id}">
+                    <span class="slider round"></span>
+                </label>
+            </td>
         `;
 
-        procedureListContainer.appendChild(procedureItem);
+        procedureListContainer.appendChild(procedureRow);
     });
 }
 

--- a/style.css
+++ b/style.css
@@ -664,30 +664,30 @@ button:hover {
    Selector Page Styles
    ================================= */
 
-.procedure-list-container {
+.procedure-table {
+    width: 100%;
+    border-collapse: collapse;
     max-width: 800px;
     margin: 20px auto;
-    padding: 20px;
     background-color: var(--background-secondary);
     border-radius: 8px;
+    overflow: hidden; /* Clips the corners of the rows */
 }
 
-.procedure-item {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 15px 10px;
+.procedure-table th {
+    font-weight: bold;
+}
+
+.procedure-table th, .procedure-table td {
+    padding: 4px 8px;
+    text-align: left;
     border-bottom: 1px solid var(--border-primary);
 }
 
-.procedure-item:last-child {
+.procedure-item:last-child td {
     border-bottom: none;
 }
 
-.procedure-name {
-    font-size: 1.1em;
-    color: var(--text-primary);
-}
 
 /* The switch - the box around the slider */
 .switch {


### PR DESCRIPTION
This commit changes the procedure selection page to display the list of procedures in a table instead of a simple list.

The new table includes the following columns: cpt_code, abbreviation, description, modality, and wrVU.

The final column contains the toggle switch to control the visibility of the procedure on the main page.

The styling has been updated to make the table clear and easy to read, with a bold header and minimal padding.