### PR TITLE
Feature: Add selected procedures to a new column

### DIFF
--- a/main.js
+++ b/main.js
@@ -658,6 +658,7 @@ function attachEventListeners() {
 }
 
 async function initializeApp() {
+    sessionStorage.removeItem('targetColumnDisplayOrder');
     const { data: { user } } = await supaClient.auth.getUser();
     if (!user) {
         window.location.href = 'index.html';


### PR DESCRIPTION
When a user adds procedures from the selector page, they are now added to a new, dedicated column instead of the end of the first column.

- A new column is created in `user_columns` for the first procedure selected during a visit to the selector page.
- All subsequent procedures selected during that same visit are stacked in that same new column.
- The state is managed using `sessionStorage`, which is cleared when the main application page is loaded, ensuring that the next visit to the selector page will generate another new column.