### PR TITLE
Fix login redirection race condition

### DIFF
--- a/script.js
+++ b/script.js
@@ -39,7 +39,29 @@ async function handleLogin(event) {
         console.error('Login failed:', error);
     } else if (data.user) {
         console.log('Login successful:', data.user);
-        window.location.href = 'start.html'; // Redirect to start.html, not main.html
+
+        // Check for an active shift
+        const { data: activeShift, error: shiftError } = await supaClient
+            .from('shifts')
+            .select('id')
+            .eq('user_id', data.user.id)
+            .is('shift_end_time', null)
+            .limit(1)
+            .single();
+
+        if (shiftError && shiftError.code !== 'PGRST116') { // PGRST116: "The query returned no rows" which is not an error here
+            console.error('Error checking for active shift:', shiftError);
+            errorMessage.textContent = 'Error checking for active shift.';
+            return;
+        }
+
+        if (activeShift) {
+            // If active shift exists, redirect to main page
+            window.location.href = 'main.html';
+        } else {
+            // Otherwise, redirect to the start shift page
+            window.location.href = 'start.html';
+        }
     }
 }
 


### PR DESCRIPTION
Previously, the application would always redirect to the 'start new shift' page after login, and then asynchronously check for an active shift. This created a race condition where a user could start a new shift before being redirected to the main page, resulting in multiple active shifts.

This change moves the active shift check to the login flow in `script.js`. After a successful login, the application now checks for an active shift *before* redirecting the user. If an active shift is found, the user is sent directly to the main page (`main.html`). Otherwise, they are sent to the start shift page (`start.html`).